### PR TITLE
Pull user creds per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Desired features in order of most likely implementation:
 
 ### App Todos
 
-- Config validation on bootstrap - decide which fields are non-optional, and croak (or something) if not present or found
+- ✅ Config validation on bootstrap - decide which fields are non-optional, and croak (or something) if not present or found
 - JSON validation for backend API endpoints
 
 ## Tests
@@ -199,7 +199,7 @@ This service's pages are rendered using the Astro UXDS from Rocket Communication
 
 - Mojolicious Framework (https://github.com/mojolicious/mojo) and various other CPAN libraries
 - Astro UXDS from RocketCommunicationsInc (https://github.com/RocketCommunicationsInc)
-- AgGrid Community (v23.2.1) (www.ag-grid.com)
+- Ag-Grid Community (v23.2.1) (www.ag-grid.com)
 - Preact.js (https://github.com/preactjs/preact)
 - toastify-js (https://github.com/apvarun/toastify-js)
 - htm (https://github.com/developit/htm)

--- a/lib/Constants.pm
+++ b/lib/Constants.pm
@@ -4,7 +4,7 @@ package Constants;
 
 use constant HTTP_OK => 200;
 use constant HTTP_CREATED => 201;
-use constant HTTP_NO_RESPONSE => 204;
+use constant HTTP_NO_CONTENT => 204;
 use constant HTTP_BAD_REQUEST => 400;
 use constant HTTP_FORBIDDEN => 403;
 use constant HTTP_NOT_FOUND => 404;

--- a/lib/Constants.pm
+++ b/lib/Constants.pm
@@ -2,12 +2,12 @@ package Constants;
 
 # package to alias HTTP statuses to plain english
 
-use constant HTTP_OK => 200;
-use constant HTTP_CREATED => 201;
-use constant HTTP_NO_CONTENT => 204;
+use constant HTTP_OK          => 200;
+use constant HTTP_CREATED     => 201;
+use constant HTTP_NO_CONTENT  => 204;
 use constant HTTP_BAD_REQUEST => 400;
-use constant HTTP_FORBIDDEN => 403;
-use constant HTTP_NOT_FOUND => 404;
-use constant HTTP_CONFLICT => 409;
+use constant HTTP_FORBIDDEN   => 403;
+use constant HTTP_NOT_FOUND   => 404;
+use constant HTTP_CONFLICT    => 409;
 
 1;

--- a/lib/Controller/AdminController.pm
+++ b/lib/Controller/AdminController.pm
@@ -106,7 +106,7 @@ sub users_delete ($self, $c) {
   if ($c->req->param('email')) {
     my $user = $self->user_service->delete_single_user($c);
     if ($user) {
-      return $c->render(json => {message => 'User Deleted'}, status => Constants::HTTP_NO_RESPONSE);
+      return $c->render(json => {message => 'User Deleted'}, status => Constants::HTTP_OK);
     } else {
       $c->render(json => {message => 'User not found'}, status => Constants::HTTP_NOT_FOUND);
     }

--- a/lib/Gateway.pm
+++ b/lib/Gateway.pm
@@ -22,7 +22,7 @@ has 'user_controller';
 
 # we'll check the config file routes do not match these as we do not
 # want these to get overriden - ever
-my $reserved_routes = [ '/admin', '/auth', '/login', '/logout' ];
+my $reserved_routes = ['/admin', '/auth', '/login', '/logout'];
 
 sub startup ($self) {
   my $config = $self->plugin('JSONConfig');
@@ -157,19 +157,20 @@ sub startup ($self) {
   $admin_routes->get('/' => sub ($c) { $self->admin_controller->admin_page_get($c) });
   $admin_routes->post('/users' => sub ($c) { $self->admin_controller->add_user_post($c) });
   $admin_routes->put('/users' => sub ($c) { $self->admin_controller->update_user_put($c) });
-  $admin_routes->get('/users'     => sub ($c) { $self->admin_controller->users_get($c) });
+  $admin_routes->get('/users' => sub ($c) { $self->admin_controller->users_get($c) });
   $admin_routes->delete('/users' => sub ($c) { $self->admin_controller->users_delete($c) });
 
   # Logs fetch routes
   if ($self->config->{enable_logging}) {
     $admin_routes->get('/http_logs' => sub ($c) { $self->admin_controller->get_http_logs($c) });
   } else {
-    $admin_routes->get('/http_logs' => sub ($c) { $c->render(json => { message => "Feature Disabled"}, status => Constants::HTTP_FORBIDDEN ); });
+    $admin_routes->get('/http_logs' =>
+        sub ($c) { $c->render(json => {message => "Feature Disabled"}, status => Constants::HTTP_FORBIDDEN); });
   }
 
   # these routes are just for authenticated (logged in users)
   #
-  # show the password change form 
+  # show the password change form
   $authorized_routes->get('/auth/password/change' => sub ($c) { $self->user_controller->password_change_form_get($c) });
   $authorized_routes->post('/auth/password/change' => sub ($c) { $self->user_controller->password_change_post($c) });
 
@@ -206,25 +207,25 @@ sub startup ($self) {
   }
 }
 
-sub validate_config($self) {
+sub validate_config ($self) {
   my $config = joi->object->props(
-    login_page_title   => joi->string,
-    enable_logging => joi->boolean,
-    logging_ignore_paths  => joi->array,
-    secret => joi->string->min(1)->required,
-    admin_user => joi->email->required,
-    admin_pass => joi->string(1)->required,
-    db_type => joi->string->enum(["pg", "sqlite"]),
-    db_uri => joi->string,
-    cookie_name => joi->string,
+    login_page_title        => joi->string,
+    enable_logging          => joi->boolean,
+    logging_ignore_paths    => joi->array,
+    secret                  => joi->string->min(1)->required,
+    admin_user              => joi->email->required,
+    admin_pass              => joi->string(1)->required,
+    db_type                 => joi->string->enum(["pg", "sqlite"]),
+    db_uri                  => joi->string,
+    cookie_name             => joi->string,
     strip_headers_to_client => joi->array,
-    jwt_secret => joi->string->required,
-    routes => joi->object->required,
-    password_valid_days => joi->number->positive->required,
-    password_complexity => joi->object->required,
-    default_route => joi->object->required,
-    test => joi->boolean,
-    config_override => joi->boolean # this is put in by Mojo on config overrides in testing
+    jwt_secret              => joi->string->required,
+    routes                  => joi->object->required,
+    password_valid_days     => joi->number->positive->required,
+    password_complexity     => joi->object->required,
+    default_route           => joi->object->required,
+    test                    => joi->boolean,
+    config_override         => joi->boolean    # this is put in by Mojo on config overrides in testing
   );
 
   say "Validating config...";
@@ -235,10 +236,10 @@ sub validate_config($self) {
 
   my $password_complex_config = joi->object->props(
     min_length => joi->number->min(1)->required,
-    alphas => joi->number->min(0)->required,
-    numbers => joi->number->min(0)->required,
-    specials => joi->number->min(0)->required,
-    spaces => joi->boolean->required
+    alphas     => joi->number->min(0)->required,
+    numbers    => joi->number->min(0)->required,
+    specials   => joi->number->min(0)->required,
+    spaces     => joi->boolean->required
   );
 
   say "Validating password complexity config...";
@@ -248,19 +249,19 @@ sub validate_config($self) {
   }
 
   my $default_route_config = joi->object->props(
-    uri => joi->string->required,
-    enable_jwt => joi->boolean,
+    uri            => joi->string->required,
+    enable_jwt     => joi->boolean,
     requires_login => joi->boolean,
-    jwt_claims => joi->object,
-    transforms => joi->array,
-    other_headers => joi->object
+    jwt_claims     => joi->object,
+    transforms     => joi->array,
+    other_headers  => joi->object
   );
 
   say "Validating default route config...";
   @errors = $default_route_config->validate($self->config->{default_route});
   if (@errors) {
     die @errors;
-  } 
+  }
 
   say "Validating route config...";
   for my $route (keys($self->config->{routes}->%*)) {

--- a/lib/Service/HttpLogService.pm
+++ b/lib/Service/HttpLogService.pm
@@ -271,7 +271,6 @@ sub get_logs (
   )->@*;
 
   # get the items from the built query
-  say $query_bindings->@*;
   my $items = $self->db->query($query, $query_bindings->@*)->hashes;
 
   # get the count of the whole, unpaged/unoffset'd resultset so our pagination UIs will

--- a/lib/Service/UserService.pm
+++ b/lib/Service/UserService.pm
@@ -32,7 +32,7 @@ sub check_user_status ($self, $c) {
 
   # if there's no current_user populated in the session cookie
   # then we're not authenticated, OR if we fail user lookup, then re-direct to the sign-in page...
-  if (!$email || !defined(do { $record = $self->_get_user($email) })) {
+  if (!$email || !defined(do { $record = $self->_get_user($email); $record; })) {
 
     # set return_to value to go back to initially requested url
     # dont allow redirect back to itself - default to /
@@ -301,7 +301,6 @@ sub get_gmstamp {
 #
 # returns time since given date stamp (in ISO 8601 format) in days
 sub get_days_since_gmstamp ($self, $time) {
-  say $time;
   if (defined($self->config->{db_type}) && $self->config->{db_type} eq 'pg') {
 
     # consider if time format is of varying formats for pg

--- a/lib/Service/UserService.pm
+++ b/lib/Service/UserService.pm
@@ -10,7 +10,7 @@ has 'db';
 has 'config';
 has 'password_util' => sub { Password::Utils->new };
 
-# other fields/keys allowed to POST/PUT besides the the email field (otherwise they're ignored)
+# other fields/keys ALLOWED to POST/PUT (otherwise they're ignored)
 has 'user_obj_allowed_fields' => sub { ['reset_password', 'first_name', 'last_name', 'is_admin', 'user_id'] };
 
 # creates a default admin user if it doesnt exist
@@ -112,7 +112,7 @@ sub do_login ($self, $c) {
     # and return them to where they were trying to go to (or default to /)
     $self->db->update("users", {last_login => $self->get_gmstamp()}, {email => $username});
     $record = $self->_get_user($username);
-    $c->session->{user} = { email => $record->{email}};
+    $c->session->{user} = {email => $record->{email}};
     $c->redirect_to($c->flash('return_to') // '/');
   } else {
     $c->render('login_page', login_failed => 1);
@@ -128,8 +128,8 @@ sub _user_exists ($self, $username) {
 }
 
 sub get_all_users ($self, $c) {
-  my $users = $self->db->select('users', ['email', 'reset_password', 'user_id', 'last_reset', 'last_login', 'is_admin'])
-    ->hashes;
+  my $users = $self->db->select('users',
+    ['email', 'reset_password', 'user_id', 'last_reset', 'last_login', 'is_admin', 'first_name', 'last_name'])->hashes;
   $c->render(json => $users);
 }
 

--- a/lib/Utils.pm
+++ b/lib/Utils.pm
@@ -24,9 +24,7 @@ sub detect_gremlins ($in) {
 sub validate_ISO_string ($str) {
   return 0 if $str !~ m/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d$/;
 
-  eval {
-    Time::Piece->strptime($str, "%Y-%m-%dT%H:%M:%S");
-  };
+  eval { Time::Piece->strptime($str, "%Y-%m-%dT%H:%M:%S"); };
 
   if ($@) { return 0; }
 

--- a/t/gateway.t
+++ b/t/gateway.t
@@ -202,7 +202,7 @@ subtest 'Test User Login/Logout/Admin operations' => sub {
 
   $t->delete_ok('/admin/users')->status_is(Constants::HTTP_BAD_REQUEST, 'Bad request');
   $t->delete_ok('/admin/users?email=test2@test.com')->status_is(Constants::HTTP_NOT_FOUND, 'Bogus user delete');
-  $t->delete_ok('/admin/users?email=test@test.com')->status_is(204, 'Successfully deleted user');
+  $t->delete_ok('/admin/users?email=test@test.com')->status_is(Constants::HTTP_OK, 'Successfully deleted user');
 
   # trust but verify user deleted
   $t->get_ok('/admin/users')->status_is(Constants::HTTP_OK)


### PR DESCRIPTION
So until now, gateway would cache the user record in the session's encrypted cookie... but this doesn't scale for adding more configurable things to the user object.  Those would only get realized once the user logged out or session expired and the new record pulled from the DB.  Now we just store the user's email in the cookie to tell the API who it is (if the session cookie is valid we're assuming).  This keeps the session cookie info purely as "AuthN" (who we are), and for "AuthZ" we'll hit the db per request - just like any other stateless API - to pull the latest and greatest for what the user can DO.