### PR TITLE
addl route support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # github incorrectly classifies some source as perl6/raku for some reason
 # these override that behavior
 
+*.css linguist-vendored
 *.pm linguist-language=perl
 *.pl linguist-language=perl
 *.t linguist-language=perl

--- a/lib/Service/ConfigValidationService.pm
+++ b/lib/Service/ConfigValidationService.pm
@@ -65,7 +65,8 @@ sub validate_config ($self) {
     requires_login => joi->boolean,
     jwt_claims     => joi->object,
     transforms     => joi->array,
-    other_headers  => joi->object
+    other_headers  => joi->object,
+    additional_paths => joi->array,
   );
 
   # validation spec for a local / template spec

--- a/lib/Service/Proxy.pm
+++ b/lib/Service/Proxy.pm
@@ -5,27 +5,75 @@ use Mojo::JWT;
 has 'config';
 has 'ua';
 
+sub _find_route_spec ($self, $name) {
+  my $r = $self->config->{ routes }->{ $name };
+
+  if (!$r) {
+    # if '$name' was not a main path spec in the config (e.g. a hash key), then
+    # take all route specs from the config, and grab out their paths, and any add'l paths
+    # then finally flatten all that into an array
+    my $sub_paths = Mojo::Collection::c(keys %{ $self->config->{ routes } })->grep(sub ($spec) {
+      return
+        defined($self->config->{ routes }->{ $spec }->{ additional_paths })
+        && @{ $self->config->{ routes }->{ $spec }->{ additional_paths } } > 0;
+    })->map(sub ($spec) {
+      my @paths  = @{ $self->config->{ routes }->{ $spec }->{ additional_paths } };
+      my @retVal = ();
+      for my $p (@paths) {
+        push @retVal, { $p => $spec };
+      }
+      return \@paths;
+    })->flatten;
+    
+    # look through all these flattened route paths, and see
+    # if we find the one that matches '$name'
+    my $matched_spec = $sub_paths->grep(sub ($spec) {
+      my @keys = keys %{ $spec };
+      if ($keys[0] eq $name) {
+        return $spec->{ $name };
+      }
+    })->to_array;
+
+    if (@{ $matched_spec } > 0) {
+
+      # return the matched spec from the config
+      return $matched_spec->[0];
+    } else {
+
+      # fallback to default route
+      return $self->config->{ default_route };
+    }
+  } else {
+
+    # return the main matched spec (i.e. was not a nested/add'l path)
+    return $r;
+  }
+}
+
 # takes the request object ($c) named route from the config
 sub proxy ($self, $c, $name) {
-  my $route_spec = $self->config->{routes}->{$name} // $self->config->{default_route};
-  if (defined($route_spec->{template_name})) {
+
+  # find the route spec from the config (note: it may be in a nested 'additional_paths', so look there too)
+  my $route_spec = $self->_find_route_spec($name);
+
+  if (defined($route_spec->{ template_name })) {
     # this isn't a request to be proxied, its just a local template render (or inline render)
-    if ($route_spec->{template_name} =~ m/^<%=/) {
-      $c->render(inline => $route_spec->{template_name});
+    if ($route_spec->{ template_name } =~ m/^<%=/) {
+      $c->render(inline => $route_spec->{ template_name });
     } else {
-      $c->render(template => $route_spec->{template_name});
+      $c->render(template => $route_spec->{ template_name });
     }
     return;
   }
 
-  my $request    = $c->req->clone;
-  my $uri        = $route_spec->{uri};
+  my $request = $c->req->clone;
+  my $uri     = $route_spec->{ uri };
 
-  if ( $route_spec->{rewrite_path}
-    && defined($route_spec->{rewrite_path}->{match})
-    && defined($route_spec->{rewrite_path}->{with})) {
-    my $match    = $route_spec->{rewrite_path}->{match};
-    my $with     = $route_spec->{rewrite_path}->{with};
+  if ( $route_spec->{ rewrite_path }
+    && defined($route_spec->{ rewrite_path }->{ match })
+    && defined($route_spec->{ rewrite_path }->{ with })) {
+    my $match    = $route_spec->{ rewrite_path }->{ match };
+    my $with     = $route_spec->{ rewrite_path }->{ with };
     my $new_path = ($c->req->url->path =~ s/$match/$with/re);
     $c->req->url->path($new_path);
   }
@@ -35,19 +83,19 @@ sub proxy ($self, $c, $name) {
   $request->url(Mojo::URL->new($uri . $c->req->url));
 
   # see if we wanna use JWT for this proxy route
-  if ($route_spec->{enable_jwt}) {
+  if ($route_spec->{ enable_jwt }) {
     my $claims = {};
-    for my $claim (keys %{$route_spec->{jwt_claims}}) {
-      $claims->{$claim} = eval $route_spec->{jwt_claims}->{$claim};
+    for my $claim (keys %{ $route_spec->{ jwt_claims } }) {
+      $claims->{ $claim } = eval $route_spec->{ jwt_claims }->{ $claim };
     }
-    my $jwt = Mojo::JWT->new(claims => $claims, secret => $self->config->{jwt_secret});
+    my $jwt = Mojo::JWT->new(claims => $claims, secret => $self->config->{ jwt_secret });
 
     $request->headers->add('Authorization', 'Bearer ' . $jwt->encode);
   }
 
   # add any other static-text headers specified in our config json
-  for my $header (keys %{$route_spec->{other_headers}}) {
-    $request->headers->add($header => $route_spec->{other_headers}->{$header});
+  for my $header (keys %{ $route_spec->{ other_headers } }) {
+    $request->headers->add($header => $route_spec->{ other_headers }->{ $header });
   }
 
   my $tx = $self->ua->start(Mojo::Transaction::HTTP->new(req => $request));
@@ -59,11 +107,11 @@ sub proxy ($self, $c, $name) {
     my $body = $res->body;
 
     # do any transforms specified for this route
-    if ($route_spec->{transforms}) {
-      for my $transform (@{$route_spec->{transforms}}) {
-        my $condition = eval $transform->{condition};
+    if ($route_spec->{ transforms }) {
+      for my $transform (@{ $route_spec->{ transforms } }) {
+        my $condition = eval $transform->{ condition };
         if ($condition) {
-          eval $transform->{action};
+          eval $transform->{ action };
           $res->headers->content_length(length($body));
           $res->body($body);
         }

--- a/lib/Service/Proxy.pm
+++ b/lib/Service/Proxy.pm
@@ -5,34 +5,42 @@ use Mojo::JWT;
 has 'config';
 has 'ua';
 
+#
+# Find the route spec information in the config given 
+# the name of the route spec (the matched route spec the mojo router used -- e.g. /anyone/**) 
 sub _find_route_spec ($self, $name) {
+    use Data::Dumper;
+    use Test::More;
   my $r = $self->config->{ routes }->{ $name };
 
   if (!$r) {
+
     # if '$name' was not a main path spec in the config (e.g. a hash key), then
     # take all route specs from the config, and grab out their paths, and any add'l paths
     # then finally flatten all that into an array
-    my $sub_paths = Mojo::Collection::c(keys %{ $self->config->{ routes } })->grep(sub ($spec) {
-      return
-        defined($self->config->{ routes }->{ $spec }->{ additional_paths })
+    my $sub_paths = Mojo::Collection::c(keys %{ $self->config->{ routes } })->map(sub ($spec) {
+      return $self->config->{ routes }->{ $spec }
+        if defined($self->config->{ routes }->{ $spec }->{ additional_paths })
         && @{ $self->config->{ routes }->{ $spec }->{ additional_paths } } > 0;
-    })->map(sub ($spec) {
-      my @paths  = @{ $self->config->{ routes }->{ $spec }->{ additional_paths } };
+    })->compact->map(sub ($spec) {
+      my @paths  = @{ $spec->{ additional_paths } };
       my @retVal = ();
       for my $p (@paths) {
         push @retVal, { $p => $spec };
       }
-      return \@paths;
+      return \@retVal;
     })->flatten;
     
+
     # look through all these flattened route paths, and see
     # if we find the one that matches '$name'
-    my $matched_spec = $sub_paths->grep(sub ($spec) {
+    my $matched_spec = $sub_paths->map(sub ($spec) {
       my @keys = keys %{ $spec };
-      if ($keys[0] eq $name) {
+      
+      if (@keys > 0 && $keys[0] eq $name) {
         return $spec->{ $name };
       }
-    })->to_array;
+    })->compact->to_array;
 
     if (@{ $matched_spec } > 0) {
 
@@ -50,13 +58,14 @@ sub _find_route_spec ($self, $name) {
   }
 }
 
-# takes the request object ($c) named route from the config
+# takes the request object ($c) and the matched route from the config
+# and does what its settings dictate (e.g. proxy to uri or return a template, inline template, etc)
 sub proxy ($self, $c, $name) {
 
   # find the route spec from the config (note: it may be in a nested 'additional_paths', so look there too)
   my $route_spec = $self->_find_route_spec($name);
-
   if (defined($route_spec->{ template_name })) {
+
     # this isn't a request to be proxied, its just a local template render (or inline render)
     if ($route_spec->{ template_name } =~ m/^<%=/) {
       $c->render(inline => $route_spec->{ template_name });

--- a/t/route_matching.t
+++ b/t/route_matching.t
@@ -1,0 +1,38 @@
+use Mojolicious;
+use Test::Mojo;
+use Test::More;
+use Mojo::UserAgent -signatures;
+use Gateway;
+use Constants;
+
+# Tests route matching combinations from the config
+
+subtest 'Check matches compound spec' => sub {
+  my $options = {
+    test       => 1,
+    admin_user => 'admin@test.com',
+    admin_pass => 'testpass',
+    secret     => 'secret',
+    jwt_secret => 'secret',
+    routes     => {
+      '/'         => { uri              => "http://localhost:8080/frontend", enable_jwt => 1, requires_login => 1 },
+      '/everyone' => { additional_paths => ['/every-one'], requires_login => 0, template_name => "<%= Hello World %>" },
+      '/anyone'   => { requires_login   => 0,              uri            => "http://localhost:8080/anyone" },
+      '/api'      => { uri              => "http://localhost:8080/api", enable_jwt => 1, requires_login => 1 }
+    },
+    default_route       => { uri => 'https://localhost:8080/frontend', requires_login => 1 },
+    password_valid_days => 60,
+    password_complexity => { min_length => 8, alphas => 1, numbers => 1, specials => 1, spaces => 0 }
+  };
+
+  my $t = Test::Mojo->new('Gateway', $options);
+  $t->ua->max_redirects(3);
+
+  $t->get_ok('/everyone')->content_like(qr/Hello World/, 'Routes to everyone page 1');
+  $t->get_ok('/every-one')->content_like(qr/Hello World/, 'Routes to everyone page 2');
+  $t->get_ok('/every-one/')->content_like(qr/Hello World/, 'Routes to everyone page 3');
+  $t->get_ok('/anyone')->content_like(qr/Whoa/, 'Bad Route page');
+  $t->get_ok('/everY--one')->content_like(qr/Login/, 'Routes to login');
+};
+
+done_testing();

--- a/t/route_matching.t
+++ b/t/route_matching.t
@@ -7,6 +7,36 @@ use Constants;
 
 # Tests route matching combinations from the config
 
+subtest 'Check can find nested, additional routes' => sub {
+  my $options = {
+    test       => 1,
+    admin_user => 'admin@test.com',
+    admin_pass => 'testpass',
+    secret     => 'secret',
+    jwt_secret => 'secret',
+    routes     => {
+      '/'         => { uri              => "http://localhost:8080/frontend", enable_jwt => 1, requires_login => 1 },
+      '/everyone' => { additional_paths => ['/every-one', '/anybody/**' ], requires_login => 0, template_name => "<%= Hello World %>" },
+      '/anyone'   => { requires_login   => 0,              uri            => "http://localhost:8080/anyone" },
+      '/api'      => { uri              => "http://localhost:8080/api", enable_jwt => 1, requires_login => 1 }
+    },
+    default_route       => { uri => 'https://localhost:8080/frontend', requires_login => 1 },
+    password_valid_days => 60,
+    password_complexity => { min_length => 8, alphas => 1, numbers => 1, specials => 1, spaces => 0 }
+  };
+  my $proxy = Service::Proxy->new(config => $options);
+  ok $proxy->_find_route_spec('/')->{uri} eq "http://localhost:8080/frontend";
+  ok $proxy->_find_route_spec('/everyone')->{template_name} eq "<%= Hello World %>";
+  ok $proxy->_find_route_spec('/every-one')->{template_name} eq "<%= Hello World %>";
+  ok $proxy->_find_route_spec('/anybody/**')->{template_name} eq "<%= Hello World %>";
+  ok !defined($proxy->_find_route_spec('/anyone')->{template_name});
+  ok $proxy->_find_route_spec('/anyone')->{uri} eq "http://localhost:8080/anyone";
+
+  # goes to default fallback route
+  ok $proxy->_find_route_spec('/whatever')->{uri} eq "https://localhost:8080/frontend";
+
+};
+
 subtest 'Check matches compound spec' => sub {
   my $options = {
     test       => 1,
@@ -16,7 +46,7 @@ subtest 'Check matches compound spec' => sub {
     jwt_secret => 'secret',
     routes     => {
       '/'         => { uri              => "http://localhost:8080/frontend", enable_jwt => 1, requires_login => 1 },
-      '/everyone' => { additional_paths => ['/every-one'], requires_login => 0, template_name => "<%= Hello World %>" },
+      '/everyone' => { additional_paths => ['/every-one', '/anybody/**'], requires_login => 0, template_name => "<%= Hello World %>" },
       '/anyone'   => { requires_login   => 0,              uri            => "http://localhost:8080/anyone" },
       '/api'      => { uri              => "http://localhost:8080/api", enable_jwt => 1, requires_login => 1 }
     },
@@ -31,6 +61,7 @@ subtest 'Check matches compound spec' => sub {
   $t->get_ok('/everyone')->content_like(qr/Hello World/, 'Routes to everyone page 1');
   $t->get_ok('/every-one')->content_like(qr/Hello World/, 'Routes to everyone page 2');
   $t->get_ok('/every-one/')->content_like(qr/Hello World/, 'Routes to everyone page 3');
+  $t->get_ok('/anybody/anywhere')->content_like(qr/Hello World/, 'Routes to everyone page 4');
   $t->get_ok('/anyone')->content_like(qr/Whoa/, 'Bad Route page');
   $t->get_ok('/everY--one')->content_like(qr/Login/, 'Routes to login');
 };


### PR DESCRIPTION
Allows the 'additional_paths' field in a route spec as a way to provide additional paths that match to that spec... vs having to duplicate path specs for each and every path you want to match.